### PR TITLE
Standardizing methods, fixing documentation, and adding a tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ Seismic dv/v analysis in Julia!
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://tclements.github.io/SeisDvv.jl/dev)
 [![Build Status](https://travis-ci.com/tclements/SeisDvv.jl.svg?branch=master)](https://travis-ci.com/tclements/SeisDvv.jl)
 
-**SeisDvv.jl** is a Julia package for computing the relative change in seismic velocity, or dv/v. SeisDvv.jl supplies the Stretching method, Moving-Window Cross-Spectrum and Wavelet-Stretching techniques. 
+**SeisDvv.jl** is a Julia package for computing the relative change in seismic velocity, or dv/v. SeisDvv.jl supplies time-, frequency-, and wavelet-domain methods for calculating dv/v. Currently implemented algorithms include
+* Time-Domain
+  * Windowed Cross-Correlation (WCC)
+  * Trace Stretching (TS)
+  * Dynamic Time Warping (DTW)
+* Frequency-Domain
+  * Moving-Window Cross Spectrum
+* Wavelet-Domain
+  * Wavelet Cross-Spectrum (WXS)
+  * Wavelet-Transform Stretching (WTS)
+  * Wavelet-Transform Dynamic Time Warping (WTDTW)
 
 ## Installation
 
@@ -16,4 +26,4 @@ julia> using Pkg; Pkg.add(PackageSpec(url="https://github.com/tclements/SeisDvv.
 
 ## Quickstart
 
-... more to come
+Follow along with the [tutorial](https://nextjournal.com/a/MQdVdjuUHy6TGTRcdAAbH?token=SH2k5KRceh9VFTZmLFG5yJ "dv/v tutorial")!

--- a/src/SeisDvv.jl
+++ b/src/SeisDvv.jl
@@ -2,6 +2,7 @@ module SeisDvv
 
 using DSP, GLM, DataFrames, Statistics, FFTW, Interpolations, SeisNoise
 
+include("tools.jl")
 include("WCC.jl")
 include("Stretching.jl")
 include("DTW.jl")

--- a/src/Stretching.jl
+++ b/src/Stretching.jl
@@ -244,6 +244,7 @@ function stretching(ref::AbstractArray, cur::AbstractArray, t::AbstractArray,
 
          dvv[iband], cc[iband], cdp[iband], ϵ, err[iband], allC[:,iband] = stretching(ncwt1, ncwt2, t, window, fmin, fmax, dvmin=dvmin, dvmax=dvmax, ntrial=ntrial)
      end
+     ϵ = collect(range(dvmin, stop=dvmax, length=ntrial))
 
      return freqbands, dvv, cc, cdp, ϵ, err, allC
 end

--- a/src/WCC.jl
+++ b/src/WCC.jl
@@ -1,8 +1,8 @@
-export WCC, WCC_dt
+export wcc, wcc_dt
 
 """
 
-    WCC(ref, cur, t, window, fs, window_length, window_step)
+    wcc(ref, cur, t, window, fs, window_length, window_step)
 
 Measure dv/v using the windowed cross-correlation following Snieder et al., 2012
 
@@ -23,10 +23,10 @@ Measure dv/v using the windowed cross-correlation following Snieder et al., 2012
 - `dvv0::Float64`: dv/v for current correlation forced through the origin
 - `dvv0_err::Float64`: Error for calculation of dvv0 for a range of frequencies
 """
-function WCC(ref::AbstractArray, cur::AbstractArray, t::AbstractArray, window::AbstractArray, fs::Float64,
+function wcc(ref::AbstractArray, cur::AbstractArray, t::AbstractArray, window::AbstractArray, fs::Float64,
              window_length::Float64, window_step::Float64)
     # measure phase shifts
-    time_axis, delta_t, cc_max = WCC_dt(ref, cur, t, window, fs, window_length, window_step)
+    time_axis, delta_t, cc_max = wcc_dt(ref, cur, t, window, fs, window_length, window_step)
     # perform linear regression of dt/t=-dv/v
     dvv, dvv_err, int, int_err, dvv0, dvv0_err = dvv_lstsq(time_axis, delta_t)
 
@@ -35,7 +35,7 @@ end
 
 """
 
-    WCC(ref, cur, t, window, fs, window_length, window_step, freqbands; norm=true)
+    wcc(ref, cur, t, window, fs, window_length, window_step, freqbands; norm=true)
 
 Measure dv/v over a range of frequencies using the windowed cross-correlation following Snieder et al., 2012
 
@@ -59,7 +59,7 @@ Measure dv/v over a range of frequencies using the windowed cross-correlation fo
 - `dvv0::Float64`: dv/v for current correlation forced through the origin
 - `dvv0_err::Float64`: Error for calculation of dvv0 for a range of frequencies
 """
-function WCC(ref::AbstractArray, cur::AbstractArray, t::AbstractArray, window::AbstractArray, fs::Float64,
+function wcc(ref::AbstractArray, cur::AbstractArray, t::AbstractArray, window::AbstractArray, fs::Float64,
              window_length::Float64, window_step::Float64, freqbands::AbstractArray; norm::Bool=true)
      # define sampling interval
      dt = 1/fs
@@ -112,7 +112,7 @@ function WCC(ref::AbstractArray, cur::AbstractArray, t::AbstractArray, window::A
              ncwt2 = wcwt2
          end
 
-         time_axis, delta_t, cc_max = WCC_dt(ncwt1, ncwt2, t, window, fs, window_length, window_step)
+         time_axis, delta_t, cc_max = wcc_dt(ncwt1, ncwt2, t, window, fs, window_length, window_step)
          dvv[iband], dvv_err[iband], int[iband], int_err[iband], dvv0[iband], dvv0_err[iband] = dvv_lstsq(time_axis, delta_t)
      end
 
@@ -121,7 +121,7 @@ end
 
 """
 
-    WCC_dt(ref, cur, fs, tmin, window_length, window_step)
+    wcc_dt(ref, cur, fs, tmin, window_length, window_step)
 
 Measure phase shifts using the windowed cross-correlation following Snieder et al., 2012
 
@@ -139,7 +139,7 @@ Measure phase shifts using the windowed cross-correlation following Snieder et a
 - `dt::AbstractArray`: Time shifts
 - `cc_max::AbstractArray`: Maximum correlation coefficient for each window
 """
-function WCC_dt(ref::AbstractArray, cur::AbstractArray, t::AbstractArray, window::AbstractArray, fs::Float64,
+function wcc_dt(ref::AbstractArray, cur::AbstractArray, t::AbstractArray, window::AbstractArray, fs::Float64,
              window_length::Float64, window_step::Float64)
      # create time axis for mwcs
      time_axis = Array(t[window[1]] + window_length / 2. : window_step :

--- a/src/WCC.jl
+++ b/src/WCC.jl
@@ -1,14 +1,133 @@
-export WCC, WCC_dvv
+export WCC, WCC_dtt, WCC_dvv
 
 """
 
-    WCC(ref, cur, fs, tmin, window_length, window_step, maxlag)
+    WCC(ref, cur, t, window, fs, window_length, window_step)
 
-Windowed cross-correlation following Snieder et al., 2012
+Measure dv/v using the windowed cross-correlation following Snieder et al., 2012
 
 # Arguments
-- `ref::AbstractArray`: Input signal
-- `cur::AbstractArray`: Reference signal
+- `ref::AbstractArray`: Reference time series
+- `cur::AbstractArray`: Current time series
+- `t::AbstractArray`: Time axis common to ref and cur
+- `window::AbstractArray`: Indices for a subset of t over which to measure phase lags
+- `fs::Float64`: Sampling frequency
+- `window_length::Float64`: Length of time window within which to find time shifts
+- `window_step::Float64`: Time step to advance window
+
+# Returns
+- `dvv::Float64`: dv/v for current correlation for a range of frequencies
+- `dvv_err::Float64`: Error for calculation of dv/v for a range of frequencies
+- `int::Float64`: Intercept for regression calculation
+- `int_err::Float64`: Error for intercept
+- `dvv0::Float64`: dv/v for current correlation forced through the origin
+- `dvv0_err::Float64`: Error for calculation of dvv0 for a range of frequencies
+"""
+function WCC(ref::AbstractArray, cur::AbstractArray, t::AbstractArray, window::AbstractArray, fs::Float64,
+             window_length::Float64, window_step::Float64)
+    # measure phase shifts
+    time_axis, delta_t, cc_max = WCC_dtt(ref, cur, t, window, fs, window_length, window_step)
+    # perform linear regression of dt/t=-dv/v
+    dvv, dvv_err, int, int_err, dvv0, dvv0_err = WCC_dvv(time_axis, delta_t)
+
+    return dvv, dvv_err, int, int_err, dvv0, dvv0_err
+end
+
+"""
+
+    WCC(ref, cur, t, window, fs, window_length, window_step, freqbands; norm=true)
+
+Measure dv/v over a range of frequencies using the windowed cross-correlation following Snieder et al., 2012
+
+# Arguments
+- `ref::AbstractArray`: Reference time series
+- `cur::AbstractArray`: Current time series
+- `t::AbstractArray`: Time axis common to ref and cur
+- `window::AbstractArray`: Indices for a subset of t over which to measure phase lags
+- `fs::Float64`: Sampling frequency
+- `window_length::Float64`: Length of time window within which to find time shifts
+- `window_step::Float64`: Time step to advance window
+- `freqbands::AbstractArray`: Frequency bands over which to compute dv/v
+- `norm::Bool`: Whether or not to normalize signals before dv/v
+
+# Returns
+- `freqbands::AbstractArray`: Array of frequencies where dv/v was measured
+- `dvv::Float64`: dv/v for current correlation for a range of frequencies
+- `dvv_err::Float64`: Error for calculation of dv/v for a range of frequencies
+- `int::Float64`: Intercept for regression calculation
+- `int_err::Float64`: Error for intercept
+- `dvv0::Float64`: dv/v for current correlation forced through the origin
+- `dvv0_err::Float64`: Error for calculation of dvv0 for a range of frequencies
+"""
+function WCC(ref::AbstractArray, cur::AbstractArray, t::AbstractArray, window::AbstractArray, fs::Float64,
+             window_length::Float64, window_step::Float64, freqbands::AbstractArray; norm::Bool=true)
+     # define sampling interval
+     dt = 1/fs
+
+     # calculate the CWT of the time series, using identical parameters for both calculations
+     cwt1, sj, freqs, coi = cwt(ref, dt, minimum(freqbands), maximum(freqbands))
+     cwt2, sj, freqs, coi = cwt(cur, dt, minimum(freqbands), maximum(freqbands))
+
+     # if a frequency window is given (instead of a set of frequency bands), we assume
+     # dv/v should be calculated for each frequency. We construct a 2D array of the
+     # form [f1 f1; f2 f2; ...], which can be treated the same as a 2D array of frequency bands
+     if ndims(freqbands)==1
+         freqbands = hcat(freqs, freqs)
+     end
+     # number of frequency bands
+     (nbands,_) = size(freqbands)
+
+     # initialize dvv and err arrays
+     dvv = zeros(nbands)
+     dvv_err = similar(dvv)
+     int = similar(dvv)
+     int_err = similar(dvv)
+     dvv0 = similar(dvv)
+     dvv0_err = similar(dvv)
+
+     # loop over frequency bands
+     for iband=1:nbands
+         (fmin, fmax) = freqbands[iband, :]
+
+         # get current frequencies over which we apply icwt
+         # frequency checks
+         if fmax < fmin
+             println("Error: please ensure columns 1 and 2 are right frequency limits in freqbands!")
+         else
+             freq_ind = findall(f->(f>=fmin && f<=fmax), freqs)
+         end
+
+         # perform icwt
+         icwt1 = icwt(cwt1[:,freq_ind], sj[freq_ind], dt)
+         icwt2 = icwt(cwt2[:,freq_ind], sj[freq_ind], dt)
+         wcwt1 = real.(icwt1)
+         wcwt2 = real.(icwt2)
+
+         # normalize both signals, if appropriate
+         if norm
+             ncwt1 = ((wcwt1 .- mean(wcwt1)) ./ std(wcwt1))
+             ncwt2 = ((wcwt2 .- mean(wcwt2)) ./ std(wcwt2))
+         else
+             ncwt1 = wcwt1
+             ncwt2 = wcwt2
+         end
+
+         time_axis, delta_t, cc_max = WCC_dtt(ncwt1, ncwt2, t, window, fs, window_length, window_step)
+         dvv[iband], dvv_err[iband], int[iband], int_err[iband], dvv0[iband], dvv0_err[iband] = WCC_dvv(time_axis, delta_t)
+     end
+
+     return freqbands, dvv, dvv_err, int, int_err, dvv0, dvv0_err
+end
+
+"""
+
+    WCC_dtt(ref, cur, fs, tmin, window_length, window_step)
+
+Measure phase shifts using the windowed cross-correlation following Snieder et al., 2012
+
+# Arguments
+- `ref::AbstractArray`: Reference time series
+- `cur::AbstractArray`: Current time series
 - `t::AbstractArray`: Time axis common to ref and cur
 - `window::AbstractArray`: Indices for a subset of t over which to measure phase lags
 - `fs::Float64`: Sampling frequency
@@ -18,11 +137,10 @@ Windowed cross-correlation following Snieder et al., 2012
 # Returns
 - `time_axis::AbstractArray`: Center times of windows
 - `dt::AbstractArray`: Time shifts
-- `err::AbstractArray`: Errors in time shift measurements
+- `cc_max::AbstractArray`: Maximum correlation coefficient for each window
 """
-function WCC(ref::AbstractArray, cur::AbstractArray, t::AbstractArray, window::AbstractArray, fs::Float64,
+function WCC_dtt(ref::AbstractArray, cur::AbstractArray, t::AbstractArray, window::AbstractArray, fs::Float64,
              window_length::Float64, window_step::Float64)
-
      # create time axis for mwcs
      time_axis = Array(t[window[1]] + window_length / 2. : window_step :
                        t[window[end]] - window_length / 2.)
@@ -69,100 +187,34 @@ end
 
 """
 
-    WCC(ref, cur, fs, tmin, window_length, window_step, maxlag, freqbands; norm=true)
-
-Windowed cross-correlation following Snieder et al., 2012
-
-# Arguments
-- `ref::AbstractArray`: Input signal
-- `cur::AbstractArray`: Reference signal
-- `t::AbstractArray`: Time axis common to ref and cur
-- `window::AbstractArray`: Indices for a subset of t over which to measure phase lags
-- `fs::Float64`: Sampling frequency
-- `window_length::Float64`: Length of time window within which to find time shifts
-- `window_step::Float64`: Time step to advance window
-- `freqbands::AbstractArray`: Frequency bands over which to compute dv/v
-- `norm::Bool`: Whether or not to normalize signals before dv/v
-
-# Returns
-- `dt::AbstractArray`: Time shifts
-- `err::AbstractArray`: Errors in time shift measurements
-"""
-function WCC(ref::AbstractArray, cur::AbstractArray, t::AbstractArray, window::AbstractArray, fs::Float64,
-             window_length::Float64, window_step::Float64, freqbands::AbstractArray; norm::Bool=true)
-     # define sampling interval
-     dt = 1/fs
-
-     # calculate the CWT of the time series, using identical parameters for both calculations
-     cwt1, sj, freqs, coi = cwt(cur, dt, minimum(freqbands), maximum(freqbands))
-     cwt2, sj, freqs, coi = cwt(ref, dt, minimum(freqbands), maximum(freqbands))
-
-     # if a frequency window is given (instead of a set of frequency bands), we assume
-     # dv/v should be calculated for each frequency. We construct a 2D array of the
-     # form [f1 f1; f2 f2; ...], which can be treated the same as a 2D array of frequency bands
-     if ndims(freqbands)==1
-         freqbands = hcat(freqs, freqs)
-     end
-     # number of frequency bands
-     (nbands,_) = size(freqbands)
-
-     # initialize dvv and err arrays
-     dtt = zeros(nbands)
-     err = zeros(nbands)
-
-     # loop over frequency bands
-     for iband=1:nbands
-         (fmin, fmax) = freqbands[iband, :]
-
-         # get current frequencies over which we apply icwt
-         # frequency checks
-         if fmax < fmin
-             println("Error: please ensure columns 1 and 2 are right frequency limits in freqbands!")
-         else
-             freq_ind = findall(f->(f>=fmin && f<=fmax), freqs)
-         end
-
-         # perform icwt
-         icwt1 = icwt(cwt1[:,freq_ind], sj[freq_ind], dt)
-         icwt2 = icwt(cwt2[:,freq_ind], sj[freq_ind], dt)
-         wcwt1 = real.(icwt1)
-         wcwt2 = real.(icwt2)
-
-         # normalize both signals, if appropriate
-         if norm
-             ncwt1 = ((wcwt1 .- mean(wcwt1)) ./ std(wcwt1))[:]
-             ncwt2 = ((wcwt2 .- mean(wcwt2)) ./ std(wcwt2))[:]
-         else
-             ncwt1 = wcwt1[:]
-             ncwt2 = wcwt2[:]
-         end
-
-         time_axis, delta_t, cc_max = WCC(ncwt2, ncwt1, t, window, fs, window_length, window_step)
-         dtt[iband], err[iband] = WCC_dvv(time_axis, delta_t)
-     end
-
-     return freqbands, dtt, err
-end
-
-"""
-
     WCC_dvv(time_axis, dt)
 
-Regreses dv/v from dt/t measurements.
+Regress dv/v from dt/t measurements.
 
 # Arguments
 - `time_axis::AbstractArray`: Center times of windows.
 - `dt::AbstractArray`: Time shifts
 
 # Returns
-- `dvv::AbstractArray`: Velocity chnages corresponding to change in time lags
-- `err::AbstractArray`: Errors in velocity change measurements
+- `m::Float64`: dv/v for current correlation
+- `em::Float64`: Error for calculation of `m`
+- `a::Float64`: Intercept for regression calculation
+- `ea::Float64`: Error on intercept
+- `m0::Float64`: dv/v for current correlation with no intercept
+- `em0::Float64`: Error for calculation of `m0`
 """
 function WCC_dvv(time_axis::AbstractArray, dt::AbstractArray)
-    model = glm(@formula(Y ~0 + X),DataFrame(X=time_axis,Y=dt),Normal(),
-                    IdentityLink(),wts=ones(length(dt)))
-    dvv = -coef(model)[1]*100
-    err = stderror(model)[1]*100
+    # regress data using least squares
+    model0 = glm(@formula(Y ~0 + X),DataFrame(X=time_axis,Y=dt),Normal(),
+                IdentityLink(),wts=ones(length(time_axis)))
+    model = glm(@formula(Y ~ X),DataFrame(X=time_axis,Y=dt),Normal(),
+                IdentityLink(),wts=ones(length(time_axis)))
 
-    return dvv, err
+    a,m = -coef(model).*100
+    ea, em = stderror(model).*100
+
+    m0 = -coef(model0)[1]*100
+    em0 = stderror(model0)[1]*100
+
+    return m, em, a, ea, m0, em0
 end

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -1,0 +1,38 @@
+export dvv_lstsq
+
+"""
+    dvv_lstsq(time_axis, dt, w)
+
+Linear regression of phase shifts to time to give dt/t=-dv/v
+
+# Arguments
+- `time_axis::AbstractArray`: Array of lag times
+- `dt::AbstractArray`: Time shifts for each lag time
+- `w::AbstractArray`: Weights for the linear regression
+
+# Returns
+- `m::Float64`: dt/t for current correlation
+- `em::Float64`: Error for calculation of `m`
+- `a::Float64`: Intercept for regression calculation
+- `ea::Float64`: Error on intercept
+- `m0::Float64`: dt/t for current correlation with no intercept
+- `em0::Float64`: Error for calculation of `m0`
+"""
+function dvv_lstsq(time_axis::AbstractArray, dt::AbstractArray; w::AbstractArray=ones(length(time_axis)))
+    # regress data using least squares
+    # force line through origin
+    model0 = glm(@formula(Y ~0 + X),DataFrame(X=time_axis,Y=dt),Normal(),
+                IdentityLink(),wts=w)
+    # allow nonzero intercept
+    model = glm(@formula(Y ~ X),DataFrame(X=time_axis,Y=dt),Normal(),
+                IdentityLink(),wts=w)
+
+    # parameters for the regression with nonzero intercept
+    a,m = -coef(model).*100
+    ea, em = stderror(model).*100
+    # parameters for the regression through the origin
+    m0 = -coef(model0)[1]*100
+    em0 = stderror(model0)[1]*100
+
+    return m, em, a, ea, m0, em0
+end


### PR DESCRIPTION
This pull request 
* updates the README with a list of implemented dv/v methods and a link to a NextJournal tutorial
* adds parameter descriptions to the docstrings
* standardizes the way each dv/v method is called. The main changes are in the DTW and WCC methods, where I add a new function that wraps separate phase shift and dv/v regression functions. 