### PR TITLE
fix smooth() arguments and threshold of dt

### DIFF
--- a/src/MWCS.jl
+++ b/src/MWCS.jl
@@ -120,9 +120,9 @@ function mwcs(ref::AbstractArray,cur::AbstractArray,fmin::Float64,
     X = fref .* conj.(fcur)
 
     if smoothing_half_win != 0
-        dcur = sqrt.(SeisNoise.smooth(fcur2,half_win=smoothing_half_win))
-        dref = sqrt.(SeisNoise.smooth(fref2,half_win=smoothing_half_win))
-        X = SeisNoise.smooth(X, half_win=smoothing_half_win)
+        dcur = sqrt.(SeisNoise.smooth(fcur2, smoothing_half_win))
+        dref = sqrt.(SeisNoise.smooth(fref2, smoothing_half_win))
+        X = SeisNoise.smooth(X, smoothing_half_win)
     else
         dcur = sqrt.(fcur2)
         dref = sqrt.(fref2)
@@ -241,7 +241,7 @@ function mwcs_dvv(time_axis::AbstractArray, dt::AbstractArray,
     dt, err, coh = dt[tindex], err[tindex], coh[tindex]
     index = intersect(findall(x -> x .<= min_coh,coh),
                       findall(x -> x .>= max_err,err),
-                      findall(x -> abs.(x) .>= max_dt,time_axis))
+                      findall(x -> abs.(x) .>= max_dt,dt))
     dt[index] .= 0.
     err[index] .= 1.
     coh[index] .= 1.


### PR DESCRIPTION
Hi @tclements,

I fixed a couple of valuables to make them working in mwcs. This commit does not change the results of dvv so much as they might be mostly constrained by `coh` and `err`.

Here is a MWE:
```
using SeisDvv, DSP, Interpolations
# synthesize ref and cur CCF
fs = 20.0
fm = 1.0
t = -60:1/fs:60
N = length(t)
ϵ = 0.01 # true stretching factor

L = 1. + ϵ
tau = t * L

ref = sin.(2*pi*fm*t) .* gaussian(N, 0.12)
cur = LinearInterpolation(tau,ref,extrapolation_bc=Flat())(t)

window_length, window_step, smoothing_half_win = 6.0, 3.0, 5

t_axis, dt, error, mcoh = SeisDvv.mwcs(ref, cur, 0.6, 1.2, fs, -60.0, window_length, window_step, smoothing_half_win)
dvv, dvv_err, int, int_err, dvv0, dvv0_err = SeisDvv.mwcs_dvv(t_axis, dt, error, mcoh, "static",
                                0.0, 1.0, 20.0, 30.0, "both", min_coh=0.9, max_err=1.0, max_dt=0.1)

```

Output:
```
julia> dvv
0.010359221326003061
```

`MWCS.jl` works really nice in our case studies, thanks! 

Cheers,