### PR TITLE
modify the determination of coda times to adapt for symmetric coda window.

### DIFF
--- a/src/Stretching.jl
+++ b/src/Stretching.jl
@@ -82,10 +82,11 @@ function stretching(ref::AbstractArray, cur::AbstractArray, t::AbstractArray,
     end
 
     wc = π * (fmin + fmax)
-    tmin = t[window][1]
-    tmax = t[window][end]
-    t1 = minimum([tmin,tmax])
-    t2 = maximum([tmin,tmax])
+
+    # Coda window here is assumed to be either one-sided in positive or negative side, or symmetric in both sides.
+    t1 = minimum(abs.(t[window]))
+    t2 = maximum(abs.(t[window]))
+
     err = 100 * (sqrt(1-X^2)/(2*X)*sqrt((6*sqrt(π/2)*T)/(wc^2*(t2^3-t1^3))))
 
     return dvv,cc,cdp,Array(ϵ),err,allC


### PR DESCRIPTION
Hi Tim,

I recently work on the error estimation in stretching method based on Weaver et al. (2011) and found that the currant way to determine the time window `t1` and `t2` might not be adaptive for symmetric coda window on positive and negative part.
Those times used in the formulation shown in equation (20) in the article seems to be corresponding to the one-sided coda window; so if the coda window is symmetric such that it is from -50s to -20s, and then from 20s to 50s, the `t1` and `t2` could be 20s and 50s, respectively. But currently `t1` and `t2` are chosen as -50s and 50s.

Here is MWE with master branch:

```
# MWE to check the error estimation in stretching
using SeisDvv, Random, Interpolations, DSP, Printf

# synthesize dummy auto-correlations for reference and current state

dt = 0.05
dvv_true = -0.005 # true dv/v in this synthetic test
fmin = 0.1
fmax = 0.9
coda_t1 = 20 # starttime of coda window
coda_t2 = 50 # endtime of coda window

t = 0:dt:100
tlag = -100:dt:100

NT = length(t)
Random.seed!(1123)
u1 = Random.rand(NT) .- 0.5

# synthesize reference corr
ref = DSP.xcorr(u1, u1)

# synthesize stretched corr
L_stretched = 1. .- dvv_true
t_stretched = tlag * L_stretched'
Random.seed!(1123)
cur = LinearInterpolation(t_stretched, ref, extrapolation_bc=Flat())(tlag) + 0.5*Random.rand(length(tlag))

# define the coda window in symmetric on both negative and positive part

window = findall(x -> (abs(x) >= coda_t1 && abs(x) <= coda_t2), tlag)

# apply stretching method to estimate dvv and error
dvv_est, cc, _, _, err_est, _ = SeisDvv.stretching(ref, cur, tlag, window, fmin, fmax)
@printf("dvv true:%4.2f, estimated:%4.2f [percent]\n", dvv_true*100, dvv_est)

# evaluate the error in the estimation of dvv using original code
T = 1 / (fmax - fmin)
X = cc
wc = π * (fmin + fmax)
tmin = tlag[window][1]
tmax = tlag[window][end]
t1 = minimum([tmin,tmax])
t2 = maximum([tmin,tmax])

@printf("t1 and t2 are: %4.1f, %4.1f\n", t1, t2)

err_original = 100 * (sqrt(1-X^2)/(2*X)*sqrt((6*sqrt(π/2)*T)/(wc^2*(t2^3-t1^3))))

# Modified t1 and t2
t1_new = minimum(abs.(tlag[window]))
t2_new = maximum(abs.(tlag[window]))

@printf("new t1 and t2 are: %4.1f, %4.1f\n", t1_new, t2_new)

err_updated = 100 * (sqrt(1-X^2)/(2*X)*sqrt((6*sqrt(π/2)*T)/(wc^2*(t2_new^3-t1_new^3))))

@printf("err from stretching():%4.3f, reculc:%4.3f, updated:%4.3f\n", err_est, err_original, err_updated)

```
Output:
```
dvv true:-0.50, estimated:-0.49 [percent]
t1 and t2 are: -50.0, 50.0
new t1 and t2 are: 20.0, 50.0
err from stretching():0.039, reculc:0.039, updated:0.057
```

So I modified the lines to find the `t1` and `t2` to adapt for either one-sided or symmetric coda window in this commit.
I hope it will work for the error estimation in dv/v with stretching method.

Cheers,